### PR TITLE
Deprecate theme topic

### DIFF
--- a/src/commands/theme/build.ts
+++ b/src/commands/theme/build.ts
@@ -11,7 +11,7 @@ import runParallelProcesses, {
 import findProject from '../../project/findProject';
 
 export default class ThemeBuild extends Command {
-  static description = 'run gesso-related build tasks';
+  static description = '[DEPRECATED] run gesso-related build tasks';
 
   static flags = {
     help: flags.help({ char: 'h' }),

--- a/src/commands/theme/watch.ts
+++ b/src/commands/theme/watch.ts
@@ -11,7 +11,7 @@ import runParallelProcesses, {
 import findProject from '../../project/findProject';
 
 export default class ThemeWatch extends Command {
-  static description = 'run gesso-related watch tasks';
+  static description = '[DEPRECATED] run gesso-related watch tasks';
 
   static flags = {
     help: flags.help({ char: 'h' }),


### PR DESCRIPTION
This deprecates both `theme`-related commands in anticipation of their removal in a later version.