### PR TITLE
Remove orphaned containers

### DIFF
--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -25,7 +25,13 @@ export default class Down extends Command {
       );
     }
 
-    const downCommand = ['down'];
+    // The --remove-orphans flag is used to alleviate potential issues when switching
+    // container definitions (e.g., switching from nginx to apache and forgetting to
+    // run `f1 down' before doing so).
+    //
+    // This is safe to do automatically since it only removes containers, not images or
+    // volumes.
+    const downCommand = ['down', '--remove-orphans'];
     if (flags.clean) {
       downCommand.push('--rmi', 'local', '--volumes');
     }


### PR DESCRIPTION
This PR removes orphaned containers automatically when doing `f1 down`. An orphaned container is one that is still running but was removed from `docker-compose.yml`. This can sometimes cause conflicts with forwarded ports (for example, when switching from nginx to Apache), since running containers will still have the open port claimed.