### PR TITLE
Add build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
+* [`f1 build`](#f-1-build)
 * [`f1 cap:stage`](#f-1-capstage)
 * [`f1 composer`](#f-1-composer)
 * [`f1 doctor`](#f-1-doctor)
@@ -35,6 +36,22 @@ USAGE
 * [`f1 theme:watch`](#f-1-themewatch)
 * [`f1 up`](#f-1-up)
 * [`f1 wp`](#f-1-wp)
+
+## `f1 build`
+
+build or rebuild all images
+
+```
+USAGE
+  $ f1 build
+
+OPTIONS
+  -h, --help       show CLI help
+  --dry-run        print command instead of running
+  --[no-]parallel  build in parallel (defaults to true)
+```
+
+_See code: [src/commands/build.ts](https://github.com/forumone/forumone-cli/blob/v1.3.0/src/commands/build.ts)_
 
 ## `f1 cap:stage`
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,0 +1,45 @@
+import { Command, flags } from '@oclif/command';
+
+import runCompose from '../docker/runCompose';
+import findProject from '../project/findProject';
+
+export default class Build extends Command {
+  static description = 'build or rebuild all images';
+
+  static flags = {
+    help: flags.help({ char: 'h' }),
+    'dry-run': flags.boolean({
+      description: 'print command instead of running',
+    }),
+    parallel: flags.boolean({
+      allowNo: true,
+      default: true,
+      description: 'build in parallel (defaults to true)',
+    }),
+  };
+
+  static args = [];
+
+  async run() {
+    const { flags } = this.parse(Build);
+
+    const project = await findProject();
+    if (project === null || project.type !== 'compose') {
+      return this.error(
+        'Could not find a docker-compose.yml file in the current directory or any parent',
+        { exit: 1 },
+      );
+    }
+
+    const buildCommand = ['build'];
+    if (flags.parallel) {
+      buildCommand.push('--parallel');
+    }
+
+    const command = await runCompose(buildCommand, {
+      cwd: project.root,
+    });
+
+    return flags['dry-run'] ? command.dryRun() : command.run();
+  }
+}

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -38,6 +38,7 @@ export default class Build extends Command {
 
     const command = await runCompose(buildCommand, {
       cwd: project.root,
+      extraFiles: ['docker-compose.cli.yml'],
     });
 
     return flags['dry-run'] ? command.dryRun() : command.run();


### PR DESCRIPTION
This adds an `f1 build` command to a project to build all local images. This rebuilds all images, and is useful in case a CLI service (i.e., Gesso) needs a rebuild. By default, images are built in parallel, but this can be disabled in case users need to triage why a specific image build is failing.