### PR TITLE
Share ~/.ssh/config with containers

### DIFF
--- a/src/docker/getSshOptions/addKnownHostsFile.ts
+++ b/src/docker/getSshOptions/addKnownHostsFile.ts
@@ -1,16 +1,7 @@
-import os from 'os';
-import path from 'path';
-
-import fileExists from '../../util/fileExists';
+import addWellKnownFile from './addWellKnownFile';
 
 async function addKnownHostsFile(): Promise<string[]> {
-  const knownHostsFile = path.join(os.homedir(), '.ssh/known_hosts');
-
-  if (await fileExists(knownHostsFile)) {
-    return ['-v', `${knownHostsFile}:${knownHostsFile}:ro`];
-  }
-
-  return [];
+  return addWellKnownFile('known_hosts');
 }
 
 export default addKnownHostsFile;

--- a/src/docker/getSshOptions/addKnownHostsFile.ts
+++ b/src/docker/getSshOptions/addKnownHostsFile.ts
@@ -1,5 +1,8 @@
 import addWellKnownFile from './addWellKnownFile';
 
+/**
+ * Returns the `docker run` flags necessary to share the user's SSH configuration file.
+ */
 async function addKnownHostsFile(): Promise<string[]> {
   return addWellKnownFile('known_hosts');
 }

--- a/src/docker/getSshOptions/addKnownHostsFile.ts
+++ b/src/docker/getSshOptions/addKnownHostsFile.ts
@@ -1,7 +1,7 @@
 import addWellKnownFile from './addWellKnownFile';
 
 /**
- * Returns the `docker run` flags necessary to share the user's SSH configuration file.
+ * Returns the `docker run` flags necessary to share the user's known_hosts file.
  */
 async function addKnownHostsFile(): Promise<string[]> {
   return addWellKnownFile('known_hosts');

--- a/src/docker/getSshOptions/addSshConfigFile.ts
+++ b/src/docker/getSshOptions/addSshConfigFile.ts
@@ -1,7 +1,7 @@
 import addWellKnownFile from './addWellKnownFile';
 
 /**
- * Returns the `docker run` flags necessary to share the user's known_hosts file.
+ * Returns the `docker run` flags necessary to share the user's SSH configuration file.
  */
 async function addSshConfigFile() {
   return addWellKnownFile('config');

--- a/src/docker/getSshOptions/addSshConfigFile.ts
+++ b/src/docker/getSshOptions/addSshConfigFile.ts
@@ -1,5 +1,8 @@
 import addWellKnownFile from './addWellKnownFile';
 
+/**
+ * Returns the `docker run` flags necessary to share the user's known_hosts file.
+ */
 async function addSshConfigFile() {
   return addWellKnownFile('config');
 }

--- a/src/docker/getSshOptions/addSshConfigFile.ts
+++ b/src/docker/getSshOptions/addSshConfigFile.ts
@@ -1,0 +1,7 @@
+import addWellKnownFile from './addWellKnownFile';
+
+async function addSshConfigFile() {
+  return addWellKnownFile('config');
+}
+
+export default addSshConfigFile;

--- a/src/docker/getSshOptions/addWellKnownFile.ts
+++ b/src/docker/getSshOptions/addWellKnownFile.ts
@@ -1,0 +1,29 @@
+import os from 'os';
+import path from 'path';
+
+import fileExists from '../../util/fileExists';
+
+/**
+ * Returns the flags necessary to bind-mount a file from the user's `.ssh` directory.
+ * This could be their SSH config or their known_hosts file. Avoid using SSH keys; that
+ * should be handled by SSH agent forwarding instead.
+ *
+ * @param name The name of a well-known SSH file (such as `known_hosts` or `config`).
+ * @param readOnly Whether or not to mount the file as immutable in the container.
+ */
+async function addWellKnownFile(
+  name: string,
+  readOnly = true,
+): Promise<string[]> {
+  const wellKnownFile = path.join(os.homedir(), '.ssh', name);
+
+  const flags = readOnly ? ':ro' : '';
+
+  if (await fileExists(wellKnownFile)) {
+    return ['-v', `${wellKnownFile}:${wellKnownFile}${flags}`];
+  }
+
+  return [];
+}
+
+export default addWellKnownFile;

--- a/src/docker/getSshOptions/addWellKnownFile.ts
+++ b/src/docker/getSshOptions/addWellKnownFile.ts
@@ -6,7 +6,11 @@ import fileExists from '../../util/fileExists';
 /**
  * Returns the flags necessary to bind-mount a file from the user's `.ssh` directory.
  * This could be their SSH config or their known_hosts file. Avoid using SSH keys; that
- * should be handled by SSH agent forwarding instead.
+ * should be handled by SSH agent forwarding instead. If the file does not exist, no
+ * flags are returned - this prevents Docker from creating the file automatically.
+ *
+ * The return value is a promise for an array of strings intended to be spread into a
+ * list of arguments to `docker run` or compatible interfaces like `docker-compose run`.
  *
  * @param name The name of a well-known SSH file (such as `known_hosts` or `config`).
  * @param readOnly Whether or not to mount the file as immutable in the container.

--- a/src/docker/getSshOptions/getAuthSocketForMac.ts
+++ b/src/docker/getSshOptions/getAuthSocketForMac.ts
@@ -6,6 +6,7 @@ import AgentStatus from '../AgentStatus';
 import getAgentStatus from '../getAgentStatus';
 
 import addKnownHostsFile from './addKnownHostsFile';
+import addSshConfigFile from './addSshConfigFile';
 
 /**
  * Creates a synthetic `/etc/passwd` file for Mac users. At the top of `/etc/passwd` is
@@ -63,6 +64,7 @@ async function getAuthSocketForMac(): Promise<string[]> {
     '-v',
     `${passwdPath}:/etc/passwd:ro`,
     ...(await addKnownHostsFile()),
+    ...(await addSshConfigFile()),
   ];
 }
 

--- a/src/docker/getSshOptions/getAuthSocketOptions.ts
+++ b/src/docker/getSshOptions/getAuthSocketOptions.ts
@@ -2,6 +2,7 @@ import os from 'os';
 import path from 'path';
 
 import addKnownHostsFile from './addKnownHostsFile';
+import addSshConfigFile from './addSshConfigFile';
 import getAuthSocketForMac from './getAuthSocketForMac';
 
 async function getAuthSocketForLinux(authSocket: string): Promise<string[]> {
@@ -15,6 +16,7 @@ async function getAuthSocketForLinux(authSocket: string): Promise<string[]> {
     '-e',
     `SSH_AUTH_SOCK=${authSocket}`,
     ...(await addKnownHostsFile()),
+    ...(await addSshConfigFile()),
   ];
 }
 


### PR DESCRIPTION
This allows containers to see a user's SSH config (when present). The most important effect of this change is that it will allow users to use their jump box settings without having to re-enter them into their Drush aliases.