### PR TITLE
Remove buildinfo during pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "eslint \"src/**\" -f stylish --ext .ts",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "rm -rf lib tsconfig.tsbuildinfo && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "tsc --noEmit -p .",
     "version": "oclif-dev readme && git add README.md"
   },


### PR DESCRIPTION
The `tsconfig.tsbuildinfo` file generated by `tsc -b` is used for incremental compilation - the problem is that it doesn't check the output directory to determine if more build activity is needed. As a result, we have to remove it when running `npm pack` - without this change, it's possible to pack an empty tarball since TypeScript didn't think it needed to recompile anything.