### PR TITLE
Add verbose output flags for most execution tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ USAGE
 
 OPTIONS
   -h, --help       show CLI help
+  -v, --verbose    print command information prior to execution
   --dry-run        print command instead of running
   --[no-]parallel  build in parallel (defaults to true)
   --[no-]pull      pull latest docker image versions (defaults to true)
@@ -63,8 +64,9 @@ USAGE
   $ f1 cap:stage
 
 OPTIONS
-  -h, --help  show CLI help
-  --dry-run   print command instead of running
+  -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
+  --dry-run      print command instead of running
 ```
 
 _See code: [src/commands/cap/stage.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/cap/stage.ts)_
@@ -78,8 +80,9 @@ USAGE
   $ f1 composer
 
 OPTIONS
-  -h, --help  show CLI help
-  --dry-run   print command instead of running
+  -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
+  --dry-run      print command instead of running
 ```
 
 _See code: [src/commands/composer.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/composer.ts)_
@@ -108,9 +111,10 @@ USAGE
   $ f1 down
 
 OPTIONS
-  -h, --help  show CLI help
-  --clean     remove images and volumes
-  --dry-run   print command instead of running
+  -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
+  --clean        remove images and volumes
+  --dry-run      print command instead of running
 ```
 
 _See code: [src/commands/down.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/down.ts)_
@@ -124,8 +128,9 @@ USAGE
   $ f1 drush
 
 OPTIONS
-  -h, --help  show CLI help
-  --dry-run   print command instead of running it
+  -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
+  --dry-run      print command instead of running it
 ```
 
 _See code: [src/commands/drush.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/drush.ts)_
@@ -156,9 +161,10 @@ USAGE
   $ f1 init
 
 OPTIONS
-  -h, --help  show CLI help
-  --dry-run   print command instead of running
-  --next      use prerelease generator for testing
+  -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
+  --dry-run      print command instead of running
+  --next         use prerelease generator for testing
 ```
 
 _See code: [src/commands/init.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/init.ts)_
@@ -175,9 +181,10 @@ ARGUMENTS
   TARGET  directory name to create
 
 OPTIONS
-  -h, --help  show CLI help
-  --dry-run   print command instead of running
-  --next      use prerelease generator for testing
+  -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
+  --dry-run      print command instead of running
+  --next         use prerelease generator for testing
 ```
 
 _See code: [src/commands/new.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/new.ts)_
@@ -194,8 +201,9 @@ ARGUMENTS
   SERVICE  compose service name
 
 OPTIONS
-  -h, --help  show CLI help
-  --dry-run   print command instead of running it
+  -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
+  --dry-run      print command instead of running it
 ```
 
 _See code: [src/commands/run.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/run.ts)_
@@ -210,6 +218,7 @@ USAGE
 
 OPTIONS
   -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
   --css          build CSS
   --dry-run      print command instead of running
   --pattern-lab  build PL
@@ -227,6 +236,7 @@ USAGE
 
 OPTIONS
   -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
   --css          watch CSS
   --dry-run      print command instead of running
   --pattern-lab  watch PL
@@ -245,6 +255,7 @@ USAGE
 OPTIONS
   -f, --foreground  run compose in the foreground
   -h, --help        show CLI help
+  -v, --verbose     print command information prior to execution
   --dry-run         print command instead of running
   --xdebug          enable xdebug in the container
 
@@ -263,8 +274,9 @@ USAGE
   $ f1 wp
 
 OPTIONS
-  -h, --help  show CLI help
-  --dry-run   print command instead of running it
+  -h, --help     show CLI help
+  -v, --verbose  print command information prior to execution
+  --dry-run      print command instead of running it
 ```
 
 _See code: [src/commands/wp.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/wp.ts)_

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -21,6 +21,10 @@ export default class Build extends Command {
       default: true,
       description: 'pull latest docker image versions (defaults to true)',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   static args = [];
@@ -48,6 +52,11 @@ export default class Build extends Command {
       cwd: project.root,
       extraFiles: ['docker-compose.cli.yml'],
     });
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,6 +1,7 @@
 import { Command, flags } from '@oclif/command';
 
 import runCompose from '../docker/runCompose';
+import { dryRunFlag, verboseFlag } from '../flags';
 import findProject from '../project/findProject';
 
 export default class Build extends Command {
@@ -8,9 +9,7 @@ export default class Build extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
+    'dry-run': dryRunFlag,
     parallel: flags.boolean({
       allowNo: true,
       default: true,
@@ -21,10 +20,7 @@ export default class Build extends Command {
       default: true,
       description: 'pull latest docker image versions (defaults to true)',
     }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    verbose: verboseFlag,
   };
 
   static args = [];

--- a/src/commands/cap/stage.ts
+++ b/src/commands/cap/stage.ts
@@ -10,12 +10,21 @@ export default class CapStage extends Command {
     'dry-run': flags.boolean({
       description: 'print command instead of running',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   async run() {
     const { flags } = this.parse(CapStage);
 
     const command = addCapStage();
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
     return flags['dry-run'] ? command.dryRun() : command.run();
   }
 }

--- a/src/commands/cap/stage.ts
+++ b/src/commands/cap/stage.ts
@@ -1,4 +1,5 @@
 import { Command, flags } from '@oclif/command';
+import { dryRunFlag, verboseFlag } from '../../flags';
 
 import addCapStage from '../../project/addCapStage';
 
@@ -7,13 +8,8 @@ export default class CapStage extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    'dry-run': dryRunFlag,
+    verbose: verboseFlag,
   };
 
   async run() {

--- a/src/commands/composer.ts
+++ b/src/commands/composer.ts
@@ -1,6 +1,7 @@
 import { Command, flags } from '@oclif/command';
 
 import runComposer from '../docker/runComposer';
+import { dryRunFlag, verboseFlag } from '../flags';
 import findProject from '../project/findProject';
 
 export default class Composer extends Command {
@@ -8,13 +9,8 @@ export default class Composer extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    'dry-run': dryRunFlag,
+    verbose: verboseFlag,
   };
 
   // Allow extra arguments (we forward them to composer)

--- a/src/commands/composer.ts
+++ b/src/commands/composer.ts
@@ -11,6 +11,10 @@ export default class Composer extends Command {
     'dry-run': flags.boolean({
       description: 'print command instead of running',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   // Allow extra arguments (we forward them to composer)
@@ -31,6 +35,11 @@ export default class Composer extends Command {
       args: argv,
       project,
     });
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -1,6 +1,7 @@
 import { Command, flags } from '@oclif/command';
 
 import runCompose from '../docker/runCompose';
+import { dryRunFlag, verboseFlag } from '../flags';
 import findProject from '../project/findProject';
 
 export default class Down extends Command {
@@ -9,13 +10,8 @@ export default class Down extends Command {
   static flags = {
     help: flags.help({ char: 'h' }),
     clean: flags.boolean({ description: 'remove images and volumes' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    'dry-run': dryRunFlag,
+    verbose: verboseFlag,
   };
 
   async run() {

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -12,6 +12,10 @@ export default class Down extends Command {
     'dry-run': flags.boolean({
       description: 'print command instead of running',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   async run() {
@@ -40,6 +44,11 @@ export default class Down extends Command {
       cwd: project.root,
       extraFiles: ['docker-compose.cli.yml'],
     });
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/commands/drush.ts
+++ b/src/commands/drush.ts
@@ -2,6 +2,7 @@ import { Command, flags } from '@oclif/command';
 
 import checkAgentStatus from '../docker/checkAgentStatus';
 import runComposeWithSsh from '../docker/runComposeWithSsh';
+import { dryRunFlag, verboseFlag } from '../flags';
 import findProject from '../project/findProject';
 
 export default class Drush extends Command {
@@ -9,13 +10,8 @@ export default class Drush extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running it',
-    }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    'dry-run': dryRunFlag,
+    verbose: verboseFlag,
   };
 
   static strict = false;

--- a/src/commands/drush.ts
+++ b/src/commands/drush.ts
@@ -12,6 +12,10 @@ export default class Drush extends Command {
     'dry-run': flags.boolean({
       description: 'print command instead of running it',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   static strict = false;
@@ -33,6 +37,11 @@ export default class Drush extends Command {
       cwd: project.root,
       extraFiles: ['docker-compose.cli.yml'],
     });
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,6 +13,10 @@ export default class Init extends Command {
     next: flags.boolean({
       description: 'use prerelease generator for testing',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   async run() {
@@ -22,6 +26,11 @@ export default class Init extends Command {
       directory: process.cwd(),
       next: flags.next,
     });
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import Command, { flags } from '@oclif/command';
+import { dryRunFlag, verboseFlag } from '../flags';
 
 import createProject from '../project/createProject';
 
@@ -6,17 +7,12 @@ export default class Init extends Command {
   static description = 'create a new project in the current directory';
 
   static flags = {
+    'dry-run': dryRunFlag,
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
     next: flags.boolean({
       description: 'use prerelease generator for testing',
     }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    verbose: verboseFlag,
   };
 
   async run() {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
 import validFilename from 'valid-filename';
+import { dryRunFlag, verboseFlag } from '../flags';
 
 import createProject from '../project/createProject';
 
@@ -18,16 +19,11 @@ export default class New extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
+    'dry-run': dryRunFlag
     next: flags.boolean({
       description: 'use prerelease generator for testing ',
     }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    verbose: verboseFlag
   };
 
   static args = [

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -24,6 +24,10 @@ export default class New extends Command {
     next: flags.boolean({
       description: 'use prerelease generator for testing ',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   static args = [
@@ -64,6 +68,11 @@ export default class New extends Command {
       directory: targetDirectory,
       next: flags.next,
     });
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,7 @@
 import { Command, flags } from '@oclif/command';
 
 import runCompose from '../docker/runCompose';
+import { dryRunFlag, verboseFlag } from '../flags';
 import findProject from '../project/findProject';
 
 export default class Run extends Command {
@@ -8,13 +9,8 @@ export default class Run extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running it',
-    }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    'dry-run': dryRunFlag,
+    verbose: verboseFlag,
   };
 
   static args = [

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -11,6 +11,10 @@ export default class Run extends Command {
     'dry-run': flags.boolean({
       description: 'print command instead of running it',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   static args = [
@@ -35,6 +39,11 @@ export default class Run extends Command {
       cwd: project.root,
       extraFiles: ['docker-compose.cli.yml'],
     });
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/commands/theme/build.ts
+++ b/src/commands/theme/build.ts
@@ -5,6 +5,7 @@ import {
   runPatternLabBuild,
   runStylesBuild,
 } from '../../docker/gesso';
+import { dryRunFlag, verboseFlag } from '../../flags';
 import runParallelProcesses, {
   NamedCommand,
 } from '../../process/runParallelProcesses';
@@ -15,15 +16,10 @@ export default class ThemeBuild extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
+    'dry-run': dryRunFlag,
     css: flags.boolean({ description: 'build CSS' }),
     'pattern-lab': flags.boolean({ description: 'build PL' }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    verbose: verboseFlag,
   };
 
   async run() {

--- a/src/commands/theme/build.ts
+++ b/src/commands/theme/build.ts
@@ -20,6 +20,10 @@ export default class ThemeBuild extends Command {
     }),
     css: flags.boolean({ description: 'build CSS' }),
     'pattern-lab': flags.boolean({ description: 'build PL' }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   async run() {
@@ -31,6 +35,7 @@ For more information, please see https://github.com/forumone/generator-web-start
 
     const { flags } = this.parse(ThemeBuild);
     const dryRun = flags['dry-run'];
+    const verbose = flags['verbose'];
 
     const project = await findProject();
     if (project === null || project.type !== 'compose') {
@@ -64,6 +69,10 @@ For more information, please see https://github.com/forumone/generator-web-start
       return;
     }
 
+    // Run verbose output immediately before command execution.
+    if (verbose) {
+      install.dryRun();
+    }
     await install.run();
 
     const processes: NamedCommand[] = [];
@@ -75,6 +84,16 @@ For more information, please see https://github.com/forumone/generator-web-start
       processes.push({ ...patternLabCommand, name: 'pattern-lab' });
     }
 
+    // Run verbose output immediately before command execution.
+    if (verbose) {
+      if (buildStyles) {
+        stylesCommand.dryRun();
+      }
+
+      if (buildPatternLab) {
+        patternLabCommand.dryRun();
+      }
+    }
     await runParallelProcesses(processes);
   }
 }

--- a/src/commands/theme/watch.ts
+++ b/src/commands/theme/watch.ts
@@ -20,6 +20,10 @@ export default class ThemeWatch extends Command {
     }),
     css: flags.boolean({ description: 'watch CSS' }),
     'pattern-lab': flags.boolean({ description: 'watch PL' }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   async run() {
@@ -31,6 +35,7 @@ For more information, please see https://github.com/forumone/generator-web-start
 
     const { flags } = this.parse(ThemeWatch);
     const dryRun = flags['dry-run'];
+    const verbose = flags['verbose'];
 
     const project = await findProject();
     if (project === null || project.type !== 'compose') {
@@ -64,6 +69,10 @@ For more information, please see https://github.com/forumone/generator-web-start
       return;
     }
 
+    // Run verbose output immediately before command execution.
+    if (verbose) {
+      install.dryRun();
+    }
     await install.run();
 
     const processes: NamedCommand[] = [];
@@ -75,6 +84,16 @@ For more information, please see https://github.com/forumone/generator-web-start
       processes.push({ ...patternLabCommand, name: 'pattern-lab' });
     }
 
+    // Run verbose output immediately before command execution.
+    if (verbose) {
+      if (watchStyles) {
+        stylesCommand.dryRun();
+      }
+
+      if (watchPatternLab) {
+        patternLabCommand.dryRun();
+      }
+    }
     await runParallelProcesses(processes);
   }
 }

--- a/src/commands/theme/watch.ts
+++ b/src/commands/theme/watch.ts
@@ -5,6 +5,7 @@ import {
   runPatternLabWatch,
   runStylesWatch,
 } from '../../docker/gesso';
+import { dryRunFlag, verboseFlag } from '../../flags';
 import runParallelProcesses, {
   NamedCommand,
 } from '../../process/runParallelProcesses';
@@ -15,15 +16,10 @@ export default class ThemeWatch extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
+    'dry-run': dryRunFlag,
     css: flags.boolean({ description: 'watch CSS' }),
     'pattern-lab': flags.boolean({ description: 'watch PL' }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    verbose: verboseFlag,
   };
 
   async run() {

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -1,4 +1,5 @@
 import { Command, flags } from '@oclif/command';
+import { dryRunFlag, verboseFlag } from '../flags';
 
 import findProject from '../project/findProject';
 import startProject from '../project/startProject';
@@ -8,13 +9,8 @@ export default class Up extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running',
-    }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    'dry-run': dryRunFlag,
+    verbose: verboseFlag,
     foreground: flags.boolean({
       char: 'f',
       description: 'run compose in the foreground',

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -11,6 +11,10 @@ export default class Up extends Command {
     'dry-run': flags.boolean({
       description: 'print command instead of running',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
     foreground: flags.boolean({
       char: 'f',
       description: 'run compose in the foreground',
@@ -40,6 +44,12 @@ export default class Up extends Command {
       xdebug: flags.xdebug,
       xdebugProfile: flags['xdebug-profile'],
     });
+
+    // eslint-disable-next-line no-console
+    console.log(flags);
+    if (flags['verbose']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/commands/wp.ts
+++ b/src/commands/wp.ts
@@ -2,6 +2,7 @@ import { Command, flags } from '@oclif/command';
 
 import checkAgentStatus from '../docker/checkAgentStatus';
 import runComposeWithSsh from '../docker/runComposeWithSsh';
+import { dryRunFlag, verboseFlag } from '../flags';
 import findProject from '../project/findProject';
 
 export default class Wp extends Command {
@@ -9,13 +10,8 @@ export default class Wp extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': flags.boolean({
-      description: 'print command instead of running it',
-    }),
-    verbose: flags.boolean({
-      char: 'v',
-      description: 'print command information prior to execution',
-    }),
+    'dry-run': dryRunFlag,
+    verbose: verboseFlag,
   };
 
   static strict = false;

--- a/src/commands/wp.ts
+++ b/src/commands/wp.ts
@@ -12,6 +12,10 @@ export default class Wp extends Command {
     'dry-run': flags.boolean({
       description: 'print command instead of running it',
     }),
+    verbose: flags.boolean({
+      char: 'v',
+      description: 'print command information prior to execution',
+    }),
   };
 
   static strict = false;
@@ -33,6 +37,11 @@ export default class Wp extends Command {
       cwd: project.root,
       extraFiles: ['docker-compose.cli.yml'],
     });
+
+    // Output command information before execution if the verbose flag is enabled.
+    if (flags['verbose'] && !flags['dry-run']) {
+      command.dryRun();
+    }
 
     return flags['dry-run'] ? command.dryRun() : command.run();
   }

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,0 +1,10 @@
+import { flags } from '@oclif/command';
+
+export const verboseFlag = flags.boolean({
+  char: 'v',
+  description: 'print command information prior to execution',
+});
+
+export const dryRunFlag = flags.boolean({
+  description: 'print command instead of running',
+});


### PR DESCRIPTION
Add a new `--verbose|-v` flag to most execution tasks to enable output
of command context prior to execution. This is the same output output by
the `--dry-run` flag, but this flag instead allows for execution to
continue after the verbose output to enable easier debugging.