### PR TITLE
Sub generator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ USAGE
 OPTIONS
   -h, --help       show CLI help
   -v, --verbose    print command information prior to execution
-  --dry-run        print command instead of running
+  --dry-run        print command instead of running it
   --[no-]parallel  build in parallel (defaults to true)
   --[no-]pull      pull latest docker image versions (defaults to true)
 ```
@@ -66,7 +66,7 @@ USAGE
 OPTIONS
   -h, --help     show CLI help
   -v, --verbose  print command information prior to execution
-  --dry-run      print command instead of running
+  --dry-run      print command instead of running it
 ```
 
 _See code: [src/commands/cap/stage.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/cap/stage.ts)_
@@ -82,7 +82,7 @@ USAGE
 OPTIONS
   -h, --help     show CLI help
   -v, --verbose  print command information prior to execution
-  --dry-run      print command instead of running
+  --dry-run      print command instead of running it
 ```
 
 _See code: [src/commands/composer.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/composer.ts)_
@@ -114,7 +114,7 @@ OPTIONS
   -h, --help     show CLI help
   -v, --verbose  print command information prior to execution
   --clean        remove images and volumes
-  --dry-run      print command instead of running
+  --dry-run      print command instead of running it
 ```
 
 _See code: [src/commands/down.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/down.ts)_
@@ -161,10 +161,11 @@ USAGE
   $ f1 init
 
 OPTIONS
-  -h, --help     show CLI help
-  -v, --verbose  print command information prior to execution
-  --dry-run      print command instead of running
-  --next         use prerelease generator for testing
+  -h, --help                                   show CLI help
+  -v, --verbose                                print command information prior to execution
+  --dry-run                                    print command instead of running it
+  --next                                       use prerelease generator for testing
+  --sub-generator=manifest|buildkite-pipeline  run a specific sub-generator within generator-web-starter
 ```
 
 _See code: [src/commands/init.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/init.ts)_
@@ -181,10 +182,11 @@ ARGUMENTS
   TARGET  directory name to create
 
 OPTIONS
-  -h, --help     show CLI help
-  -v, --verbose  print command information prior to execution
-  --dry-run      print command instead of running
-  --next         use prerelease generator for testing
+  -h, --help                                   show CLI help
+  -v, --verbose                                print command information prior to execution
+  --dry-run                                    print command instead of running it
+  --next                                       use prerelease generator for testing
+  --sub-generator=manifest|buildkite-pipeline  run a specific sub-generator within generator-web-starter
 ```
 
 _See code: [src/commands/new.ts](https://github.com/forumone/forumone-cli/blob/v1.6.0/src/commands/new.ts)_
@@ -220,7 +222,7 @@ OPTIONS
   -h, --help     show CLI help
   -v, --verbose  print command information prior to execution
   --css          build CSS
-  --dry-run      print command instead of running
+  --dry-run      print command instead of running it
   --pattern-lab  build PL
 ```
 
@@ -238,7 +240,7 @@ OPTIONS
   -h, --help     show CLI help
   -v, --verbose  print command information prior to execution
   --css          watch CSS
-  --dry-run      print command instead of running
+  --dry-run      print command instead of running it
   --pattern-lab  watch PL
 ```
 
@@ -256,7 +258,7 @@ OPTIONS
   -f, --foreground  run compose in the foreground
   -h, --help        show CLI help
   -v, --verbose     print command information prior to execution
-  --dry-run         print command instead of running
+  --dry-run         print command instead of running it
   --xdebug          enable xdebug in the container
 
   --xdebug-profile  Enables the triggering of xdebug's profiler. See https://xdebug.org/docs/profiler for how to trigger

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,5 @@
 import Command, { flags } from '@oclif/command';
-import { dryRunFlag, verboseFlag } from '../flags';
+import { dryRunFlag, subGeneratorFlag, verboseFlag } from '../flags';
 
 import createProject from '../project/createProject';
 
@@ -12,6 +12,7 @@ export default class Init extends Command {
     next: flags.boolean({
       description: 'use prerelease generator for testing',
     }),
+    'sub-generator': subGeneratorFlag,
     verbose: verboseFlag,
   };
 
@@ -21,6 +22,7 @@ export default class Init extends Command {
     const command = createProject({
       directory: process.cwd(),
       next: flags.next,
+      subgenerator: flags['sub-generator'],
     });
 
     // Output command information before execution if the verbose flag is enabled.

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
 import validFilename from 'valid-filename';
-import { dryRunFlag, verboseFlag } from '../flags';
+import { dryRunFlag, subGeneratorFlag, verboseFlag } from '../flags';
 
 import createProject from '../project/createProject';
 
@@ -23,6 +23,7 @@ export default class New extends Command {
     next: flags.boolean({
       description: 'use prerelease generator for testing ',
     }),
+    'sub-generator': subGeneratorFlag,
     verbose: verboseFlag,
   };
 
@@ -63,6 +64,7 @@ export default class New extends Command {
     const command = createProject({
       directory: targetDirectory,
       next: flags.next,
+      subgenerator: flags['sub-generator'],
     });
 
     // Output command information before execution if the verbose flag is enabled.

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -19,11 +19,11 @@ export default class New extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    'dry-run': dryRunFlag
+    'dry-run': dryRunFlag,
     next: flags.boolean({
       description: 'use prerelease generator for testing ',
     }),
-    verbose: verboseFlag
+    verbose: verboseFlag,
   };
 
   static args = [

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -6,5 +6,10 @@ export const verboseFlag = flags.boolean({
 });
 
 export const dryRunFlag = flags.boolean({
-  description: 'print command instead of running',
+  description: 'print command instead of running it',
+});
+
+export const subGeneratorFlag = flags.string({
+  description: 'run a specific sub-generator within generator-web-starter',
+  options: ['manifest', 'buildkite-pipeline'],
 });

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -11,7 +11,7 @@ export const dryRunFlag = flags.boolean({
 
 export const subGeneratorFlag = flags.string({
   description: 'run a specific sub-generator within generator-web-starter',
-  options: ['manifest', 'buildkite-pipeline'],
+  options: ['manifest', 'buildkite-pipeline', 'code-quality'],
   // @todo Remove this dependency once the sub-generators are fully released.
   dependsOn: ['next'],
 });

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -12,4 +12,6 @@ export const dryRunFlag = flags.boolean({
 export const subGeneratorFlag = flags.string({
   description: 'run a specific sub-generator within generator-web-starter',
   options: ['manifest', 'buildkite-pipeline'],
+  // @todo Remove this dependency once the sub-generators are fully released.
+  dependsOn: ['next'],
 });

--- a/src/project/createProject.ts
+++ b/src/project/createProject.ts
@@ -3,13 +3,26 @@ import runNpx from '../process/runNpx';
 export interface CreateProjectOptions {
   directory: string;
   next: boolean;
+  subgenerator?: string;
 }
 
 // Use `npx' to ensure that users always have the latest generator version.
-function createProject({ directory, next }: CreateProjectOptions) {
+function createProject({
+  directory,
+  next,
+  subgenerator,
+}: CreateProjectOptions) {
   const tagSuffix = next ? '@next' : '';
 
-  return runNpx(['yo', 'web-starter'], {
+  const command = ['yo'];
+
+  if (subgenerator === undefined) {
+    command.push('web-starter');
+  } else {
+    command.push('web-starter:' + subgenerator);
+  }
+
+  return runNpx(command, {
     cwd: directory,
     packages: ['yo', 'generator-web-starter' + tagSuffix],
   });


### PR DESCRIPTION
Add sub-generator support to `f1 init` and `f1 new` to enable
execution of new and future sub-generators in development.

At this time two new sub-generators will be supported as part of the
upcoming release of generator-web-starter:

Manifest file
```bash
f1 init --next --sub-generator=manifest
```

Buildkite Pipeline
```bash
f1 init --next --sub-generator=buildkite-pipeline
```