### PR TITLE
Adding help text on how to escape and pass flags to certain commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ USAGE
 
 OPTIONS
   -h, --help     show CLI help
+                 Putting "--" at the end of your command, then adding additional flags (like --help) will run that flag
+                 on the native command
+
   -v, --verbose  print command information prior to execution
+
   --dry-run      print command instead of running it
 ```
 
@@ -129,7 +133,11 @@ USAGE
 
 OPTIONS
   -h, --help     show CLI help
+                 Putting "--" at the end of your command, then adding additional flags (like --help) will run that flag
+                 on the native command
+
   -v, --verbose  print command information prior to execution
+
   --dry-run      print command instead of running it
 ```
 
@@ -204,7 +212,11 @@ ARGUMENTS
 
 OPTIONS
   -h, --help     show CLI help
+                 Putting "--" at the end of your command, then adding additional flags (like --help) will run that flag
+                 on the native command
+
   -v, --verbose  print command information prior to execution
+
   --dry-run      print command instead of running it
 ```
 
@@ -277,7 +289,11 @@ USAGE
 
 OPTIONS
   -h, --help     show CLI help
+                 Putting "--" at the end of your command, then adding additional flags (like --help) will run that flag
+                 on the native command
+
   -v, --verbose  print command information prior to execution
+
   --dry-run      print command instead of running it
 ```
 

--- a/src/commands/composer.ts
+++ b/src/commands/composer.ts
@@ -8,7 +8,12 @@ export default class Composer extends Command {
   static description = 'run composer commands';
 
   static flags = {
-    help: flags.help({ char: 'h' }),
+    help: flags.help({
+      char: 'h',
+      description:
+        'show CLI help\r\n' +
+        'Putting "--" at the end of your command, then adding additional flags (like --help) will run that flag on the native command',
+    }),
     'dry-run': dryRunFlag,
     verbose: verboseFlag,
   };

--- a/src/commands/drush.ts
+++ b/src/commands/drush.ts
@@ -9,7 +9,12 @@ export default class Drush extends Command {
   static description = 'run drush commands';
 
   static flags = {
-    help: flags.help({ char: 'h' }),
+    help: flags.help({
+      char: 'h',
+      description:
+        'show CLI help\r\n' +
+        'Putting "--" at the end of your command, then adding additional flags (like --help) will run that flag on the native command',
+    }),
     'dry-run': dryRunFlag,
     verbose: verboseFlag,
   };

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,7 +8,12 @@ export default class Run extends Command {
   static description = 'run an arbitrary compose service';
 
   static flags = {
-    help: flags.help({ char: 'h' }),
+    help: flags.help({
+      char: 'h',
+      description:
+        'show CLI help\r\n' +
+        'Putting "--" at the end of your command, then adding additional flags (like --help) will run that flag on the native command',
+    }),
     'dry-run': dryRunFlag,
     verbose: verboseFlag,
   };

--- a/src/commands/wp.ts
+++ b/src/commands/wp.ts
@@ -9,7 +9,12 @@ export default class Wp extends Command {
   static description = 'run wp-cli commands';
 
   static flags = {
-    help: flags.help({ char: 'h' }),
+    help: flags.help({
+      char: 'h',
+      description:
+        'show CLI help\r\n' +
+        'Putting "--" at the end of your command, then adding additional flags (like --help) will run that flag on the native command',
+    }),
     'dry-run': dryRunFlag,
     verbose: verboseFlag,
   };


### PR DESCRIPTION
I tried to implement the class as listed here but couldn't get it to work. Wondering if it's because oclif packages are a bit out of date for the features listed. Just added a note to the various commands instead.
https://oclif.io/docs/help_classes